### PR TITLE
Bugfix for k_tuple functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: primes
 Type: Package
 Title: Fast Functions for Prime Numbers
-Version: 1.2.0
-Date: 2020-09-23
+Version: 1.3.0
+Date: 2020-10-24
 Authors@R: c(
     person("Os", "Keyes", email = "ironholds@gmail.com", role = c("aut", "cre")),
     person("Paul", "Egeler", email = "paulegeler@gmail.com", role = c("aut"), comment = c(ORCID = "0000-0001-6948-9498"))

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -68,6 +68,12 @@ k_tuple <- function(min, max, tuple) {
     .Call('_primes_k_tuple', PACKAGE = 'primes', min, max, tuple)
 }
 
+#' @rdname k_tuple
+#' @export
+sexy_prime_triplets <- function(min, max) {
+    .Call('_primes_sexy_prime_triplets', PACKAGE = 'primes', min, max)
+}
+
 #' Find the Next and Previous Prime Numbers
 #'
 #' Find the next prime numbers or previous prime numbers over a vector.

--- a/R/k_tuple.R
+++ b/R/k_tuple.R
@@ -12,7 +12,8 @@
 #'   \item `cousin_primes`: represents `c(0,4)`.
 #'   \item `third_cousin_primes`: represents `c(0,8)`.
 #'   \item `sexy_primes`: represents `c(0,6)`.
-#'   \item `sexy_prime_triplets`: represents `c(0,6,12)`.
+#'   \item `sexy_prime_triplets`: represents `c(0,6,12)`. (This relationship is
+#'   unique in that \eqn{p + 18} is guaranteed to be composite.)
 #' }
 #'
 #' The term "third cousin primes" is of the author's coinage. There is no
@@ -45,6 +46,7 @@
 #'   `tuple`.
 #' @author Paul Egeler, MS
 #' @name k_tuple
+# function(x) lapply(which(is_prime(x) & is_prime(x+2)), function(n) c(n, n+2))
 NULL
 
 #' @rdname k_tuple
@@ -61,11 +63,6 @@ cousin_primes <- function(min, max)
 #' @export
 sexy_primes <- function(min, max)
   k_tuple(min, max, c(0,6))
-
-#' @rdname k_tuple
-#' @export
-sexy_prime_triplets <- function(min, max)
-  k_tuple(min, max, c(0,6,12))
 
 #' @rdname k_tuple
 #' @export

--- a/man/k_tuple.Rd
+++ b/man/k_tuple.Rd
@@ -2,22 +2,22 @@
 % Please edit documentation in R/RcppExports.R, R/k_tuple.R
 \name{k_tuple}
 \alias{k_tuple}
+\alias{sexy_prime_triplets}
 \alias{twin_primes}
 \alias{cousin_primes}
 \alias{sexy_primes}
-\alias{sexy_prime_triplets}
 \alias{third_cousin_primes}
 \title{Prime \emph{k}-tuples}
 \usage{
 k_tuple(min, max, tuple)
+
+sexy_prime_triplets(min, max)
 
 twin_primes(min, max)
 
 cousin_primes(min, max)
 
 sexy_primes(min, max)
-
-sexy_prime_triplets(min, max)
 
 third_cousin_primes(min, max)
 }
@@ -46,7 +46,8 @@ relationships. They are listed below.
 \item \code{cousin_primes}: represents \code{c(0,4)}.
 \item \code{third_cousin_primes}: represents \code{c(0,8)}.
 \item \code{sexy_primes}: represents \code{c(0,6)}.
-\item \code{sexy_prime_triplets}: represents \code{c(0,6,12)}.
+\item \code{sexy_prime_triplets}: represents \code{c(0,6,12)}. (This relationship is
+unique in that \eqn{p + 18} is guaranteed to be composite.)
 }
 
 The term "third cousin primes" is of the author's coinage. There is no

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -125,6 +125,18 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// sexy_prime_triplets
+Rcpp::List sexy_prime_triplets(int min, int max);
+RcppExport SEXP _primes_sexy_prime_triplets(SEXP minSEXP, SEXP maxSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< int >::type min(minSEXP);
+    Rcpp::traits::input_parameter< int >::type max(maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(sexy_prime_triplets(min, max));
+    return rcpp_result_gen;
+END_RCPP
+}
 // next_prime
 Rcpp::IntegerVector next_prime(const Rcpp::IntegerVector& x);
 RcppExport SEXP _primes_next_prime(SEXP xSEXP) {
@@ -231,6 +243,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_primes_generate_n_primes", (DL_FUNC) &_primes_generate_n_primes, 1},
     {"_primes_is_prime", (DL_FUNC) &_primes_is_prime, 1},
     {"_primes_k_tuple", (DL_FUNC) &_primes_k_tuple, 3},
+    {"_primes_sexy_prime_triplets", (DL_FUNC) &_primes_sexy_prime_triplets, 2},
     {"_primes_next_prime", (DL_FUNC) &_primes_next_prime, 1},
     {"_primes_prev_prime", (DL_FUNC) &_primes_prev_prime, 1},
     {"_primes_nth_prime", (DL_FUNC) &_primes_nth_prime, 1},

--- a/src/k_tuple.cpp
+++ b/src/k_tuple.cpp
@@ -12,16 +12,20 @@ Rcpp::List k_tuple(int min, int max, std::vector<int> tuple) {
   if (tuple[0] != 0)
     Rcpp::stop("the first element of `tuple` must be zero.");
 
-  for (auto it = primes.begin(); it != (primes.end() - tuple.size() + 1); ++it) {
+  for (auto it = primes.begin(); it != primes.end(); ++it) {
     bool match = true;
-    for (int j=1; j < tuple.size(); j++) {
-      if (*(it + j) - *it != tuple[j]) {
+
+    for (auto jt = tuple.begin() + 1; jt != tuple.end(); ++jt) {
+      if (!binary_search(it, primes.end(), *it + *jt)) {
         match = false;
         break;
       }
     }
+
     if (match) {
-      std::vector<int> matching_set(it, it + tuple.size());
+      std::vector<int> matching_set(tuple.begin(), tuple.end());
+      for (auto& m : matching_set)
+        m += *it;
       out.push_back(matching_set);
     }
   }

--- a/src/primes.h
+++ b/src/primes.h
@@ -21,6 +21,7 @@ Rcpp::IntegerVector prev_prime(const Rcpp::IntegerVector& x);
 int prime_count(int n, bool upper_bound);
 int nth_prime_estimate(int n, bool upper_bound);
 Rcpp::List k_tuple(int min, int max, std::vector<int> tuple);
+Rcpp::List sexy_prime_triplets(int min, int max);
 Rcpp::List prime_factors(const Rcpp::IntegerVector& x);
 int gcd_(int m, int n);
 int scm_(int m, int n);

--- a/tests/testthat/test_k_tuple.R
+++ b/tests/testthat/test_k_tuple.R
@@ -9,15 +9,36 @@ test_that("Prime triplets are correct", {
 })
 
 test_that("Prime cousins are correct", {
+  #  OEIS A023200 and OEIS A046132 via Wikipedia
   expect_equal(
-    cousin_primes(0,29),
-    list(c(3L, 7L), c(7L, 11L), c(13L, 17L), c(19L, 23L))
+    cousin_primes(0,1000),
+    list(
+      c(3, 7), c(7, 11), c(13, 17), c(19, 23), c(37, 41), c(43, 47),
+      c(67, 71), c(79, 83), c(97, 101), c(103, 107), c(109, 113),
+      c(127, 131), c(163, 167), c(193, 197), c(223, 227), c(229, 233),
+      c(277, 281), c(307, 311), c(313, 317), c(349, 353), c(379, 383),
+      c(397, 401), c(439, 443), c(457, 461), c(463,467), c(487, 491),
+      c(499, 503), c(613, 617), c(643, 647), c(673, 677), c(739, 743),
+      c(757, 761), c(769, 773), c(823, 827), c(853, 857), c(859, 863),
+      c(877, 881), c(883, 887), c(907, 911), c(937, 941), c(967, 971)
+    )
   )
 })
 
 test_that("Sexy prime triplets are correct", {
   expect_equal(
-    sexy_prime_triplets(0,29), # p + 18 must be composite
-    list(c(7L, 13L, 19L), c(17L, 23L, 29L))
+    sexy_prime_triplets(0,23), # p + 18 must be composite
+    list(c(7L, 13L, 19L))
+  )
+  expect_equal(
+    # OEIS A046118, OEIS A046119, and OEIS: A046120 via Wikipedia
+    sexy_prime_triplets(0,1000),
+    list(
+      c(7,13,19), c(17,23,29), c(31,37,43), c(47,53,59), c(67,73,79),
+      c(97,103,109), c(101,107,113), c(151,157,163), c(167,173,179),
+      c(227,233,239), c(257,263,269), c(271,277,283), c(347,353,359),
+      c(367,373,379), c(557,563,569), c(587,593,599), c(607,613,619),
+      c(647,653,659), c(727,733,739), c(941,947,953), c(971,977,983)
+    )
   )
 })

--- a/tests/testthat/test_k_tuple.R
+++ b/tests/testthat/test_k_tuple.R
@@ -17,7 +17,7 @@ test_that("Prime cousins are correct", {
 
 test_that("Sexy prime triplets are correct", {
   expect_equal(
-    sexy_prime_triplets(0,29),
-    list(c(5L, 11L, 17L), c(7L, 13L, 19L), c(11L, 17L, 23L), c(17L, 23L, 29L))
+    sexy_prime_triplets(0,29), # p + 18 must be composite
+    list(c(7L, 13L, 19L), c(17L, 23L, 29L))
   )
 })

--- a/tests/testthat/test_k_tuple.R
+++ b/tests/testthat/test_k_tuple.R
@@ -7,3 +7,17 @@ test_that("First twin primes are correct", {
 test_that("Prime triplets are correct", {
   expect_equal(k_tuple(2,19,c(0,2,6)), list(c(5L,7L,11L), c(11L,13L,17L)))
 })
+
+test_that("Prime cousins are correct", {
+  expect_equal(
+    cousin_primes(0,29),
+    list(c(3L, 7L), c(7L, 11L), c(13L, 17L), c(19L, 23L))
+  )
+})
+
+test_that("Sexy prime triplets are correct", {
+  expect_equal(
+    sexy_prime_triplets(0,29),
+    list(c(5L, 11L, 17L), c(7L, 13L, 19L), c(11L, 17L, 23L), c(17L, 23L, 29L))
+  )
+})


### PR DESCRIPTION
Hi @Ironholds 

I noticed that the output of the `k_tuple`-derived functions were not matching the OEIS sequences. After further investigation, I realized there was a flaw with my previous implementation. In addition, I was not aware that sexy prime triplet sequences require that `p + 18` must be composite. This PR addresses those concerns and also includes more robust tests that use sequences taken directly from OEIS (via Wikipedia).

Thanks!!! 