### PR TITLE
Changing minimum R version to 4.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Fast functions for dealing with prime numbers, such as testing
     testing whether two numbers are coprime, and computing Euler's totient
     function. Most functions are vectorized for speed and convenience.
 License: MIT + file LICENSE
-Depends: R (>= 2.10)
+Depends: R (>= 4.0)
 Imports: Rcpp
 LinkingTo: Rcpp
 Suggests: testthat

--- a/inst/include/primes_RcppExports.h
+++ b/inst/include/primes_RcppExports.h
@@ -24,6 +24,384 @@ namespace primes {
         }
     }
 
+    inline int gcd_(int m, int n) {
+        typedef SEXP(*Ptr_gcd_)(SEXP,SEXP);
+        static Ptr_gcd_ p_gcd_ = NULL;
+        if (p_gcd_ == NULL) {
+            validateSignature("int(*gcd_)(int,int)");
+            p_gcd_ = (Ptr_gcd_)R_GetCCallable("primes", "_primes_gcd_");
+        }
+        RObject rcpp_result_gen;
+        {
+            RNGScope RCPP_rngScope_gen;
+            rcpp_result_gen = p_gcd_(Shield<SEXP>(Rcpp::wrap(m)), Shield<SEXP>(Rcpp::wrap(n)));
+        }
+        if (rcpp_result_gen.inherits("interrupted-error"))
+            throw Rcpp::internal::InterruptedException();
+        if (Rcpp::internal::isLongjumpSentinel(rcpp_result_gen))
+            throw Rcpp::LongjumpException(rcpp_result_gen);
+        if (rcpp_result_gen.inherits("try-error"))
+            throw Rcpp::exception(Rcpp::as<std::string>(rcpp_result_gen).c_str());
+        return Rcpp::as<int >(rcpp_result_gen);
+    }
+
+    inline int Rgcd_(const Rcpp::IntegerVector& x) {
+        typedef SEXP(*Ptr_Rgcd_)(SEXP);
+        static Ptr_Rgcd_ p_Rgcd_ = NULL;
+        if (p_Rgcd_ == NULL) {
+            validateSignature("int(*Rgcd_)(const Rcpp::IntegerVector&)");
+            p_Rgcd_ = (Ptr_Rgcd_)R_GetCCallable("primes", "_primes_Rgcd_");
+        }
+        RObject rcpp_result_gen;
+        {
+            RNGScope RCPP_rngScope_gen;
+            rcpp_result_gen = p_Rgcd_(Shield<SEXP>(Rcpp::wrap(x)));
+        }
+        if (rcpp_result_gen.inherits("interrupted-error"))
+            throw Rcpp::internal::InterruptedException();
+        if (Rcpp::internal::isLongjumpSentinel(rcpp_result_gen))
+            throw Rcpp::LongjumpException(rcpp_result_gen);
+        if (rcpp_result_gen.inherits("try-error"))
+            throw Rcpp::exception(Rcpp::as<std::string>(rcpp_result_gen).c_str());
+        return Rcpp::as<int >(rcpp_result_gen);
+    }
+
+    inline int scm_(int m, int n) {
+        typedef SEXP(*Ptr_scm_)(SEXP,SEXP);
+        static Ptr_scm_ p_scm_ = NULL;
+        if (p_scm_ == NULL) {
+            validateSignature("int(*scm_)(int,int)");
+            p_scm_ = (Ptr_scm_)R_GetCCallable("primes", "_primes_scm_");
+        }
+        RObject rcpp_result_gen;
+        {
+            RNGScope RCPP_rngScope_gen;
+            rcpp_result_gen = p_scm_(Shield<SEXP>(Rcpp::wrap(m)), Shield<SEXP>(Rcpp::wrap(n)));
+        }
+        if (rcpp_result_gen.inherits("interrupted-error"))
+            throw Rcpp::internal::InterruptedException();
+        if (Rcpp::internal::isLongjumpSentinel(rcpp_result_gen))
+            throw Rcpp::LongjumpException(rcpp_result_gen);
+        if (rcpp_result_gen.inherits("try-error"))
+            throw Rcpp::exception(Rcpp::as<std::string>(rcpp_result_gen).c_str());
+        return Rcpp::as<int >(rcpp_result_gen);
+    }
+
+    inline int Rscm_(const Rcpp::IntegerVector& x) {
+        typedef SEXP(*Ptr_Rscm_)(SEXP);
+        static Ptr_Rscm_ p_Rscm_ = NULL;
+        if (p_Rscm_ == NULL) {
+            validateSignature("int(*Rscm_)(const Rcpp::IntegerVector&)");
+            p_Rscm_ = (Ptr_Rscm_)R_GetCCallable("primes", "_primes_Rscm_");
+        }
+        RObject rcpp_result_gen;
+        {
+            RNGScope RCPP_rngScope_gen;
+            rcpp_result_gen = p_Rscm_(Shield<SEXP>(Rcpp::wrap(x)));
+        }
+        if (rcpp_result_gen.inherits("interrupted-error"))
+            throw Rcpp::internal::InterruptedException();
+        if (Rcpp::internal::isLongjumpSentinel(rcpp_result_gen))
+            throw Rcpp::LongjumpException(rcpp_result_gen);
+        if (rcpp_result_gen.inherits("try-error"))
+            throw Rcpp::exception(Rcpp::as<std::string>(rcpp_result_gen).c_str());
+        return Rcpp::as<int >(rcpp_result_gen);
+    }
+
+    inline Rcpp::IntegerVector gcd(const Rcpp::IntegerVector& m, const Rcpp::IntegerVector& n) {
+        typedef SEXP(*Ptr_gcd)(SEXP,SEXP);
+        static Ptr_gcd p_gcd = NULL;
+        if (p_gcd == NULL) {
+            validateSignature("Rcpp::IntegerVector(*gcd)(const Rcpp::IntegerVector&,const Rcpp::IntegerVector&)");
+            p_gcd = (Ptr_gcd)R_GetCCallable("primes", "_primes_gcd");
+        }
+        RObject rcpp_result_gen;
+        {
+            RNGScope RCPP_rngScope_gen;
+            rcpp_result_gen = p_gcd(Shield<SEXP>(Rcpp::wrap(m)), Shield<SEXP>(Rcpp::wrap(n)));
+        }
+        if (rcpp_result_gen.inherits("interrupted-error"))
+            throw Rcpp::internal::InterruptedException();
+        if (Rcpp::internal::isLongjumpSentinel(rcpp_result_gen))
+            throw Rcpp::LongjumpException(rcpp_result_gen);
+        if (rcpp_result_gen.inherits("try-error"))
+            throw Rcpp::exception(Rcpp::as<std::string>(rcpp_result_gen).c_str());
+        return Rcpp::as<Rcpp::IntegerVector >(rcpp_result_gen);
+    }
+
+    inline Rcpp::IntegerVector scm(const Rcpp::IntegerVector& m, const Rcpp::IntegerVector& n) {
+        typedef SEXP(*Ptr_scm)(SEXP,SEXP);
+        static Ptr_scm p_scm = NULL;
+        if (p_scm == NULL) {
+            validateSignature("Rcpp::IntegerVector(*scm)(const Rcpp::IntegerVector&,const Rcpp::IntegerVector&)");
+            p_scm = (Ptr_scm)R_GetCCallable("primes", "_primes_scm");
+        }
+        RObject rcpp_result_gen;
+        {
+            RNGScope RCPP_rngScope_gen;
+            rcpp_result_gen = p_scm(Shield<SEXP>(Rcpp::wrap(m)), Shield<SEXP>(Rcpp::wrap(n)));
+        }
+        if (rcpp_result_gen.inherits("interrupted-error"))
+            throw Rcpp::internal::InterruptedException();
+        if (Rcpp::internal::isLongjumpSentinel(rcpp_result_gen))
+            throw Rcpp::LongjumpException(rcpp_result_gen);
+        if (rcpp_result_gen.inherits("try-error"))
+            throw Rcpp::exception(Rcpp::as<std::string>(rcpp_result_gen).c_str());
+        return Rcpp::as<Rcpp::IntegerVector >(rcpp_result_gen);
+    }
+
+    inline Rcpp::LogicalVector coprime(const Rcpp::IntegerVector& m, const Rcpp::IntegerVector& n) {
+        typedef SEXP(*Ptr_coprime)(SEXP,SEXP);
+        static Ptr_coprime p_coprime = NULL;
+        if (p_coprime == NULL) {
+            validateSignature("Rcpp::LogicalVector(*coprime)(const Rcpp::IntegerVector&,const Rcpp::IntegerVector&)");
+            p_coprime = (Ptr_coprime)R_GetCCallable("primes", "_primes_coprime");
+        }
+        RObject rcpp_result_gen;
+        {
+            RNGScope RCPP_rngScope_gen;
+            rcpp_result_gen = p_coprime(Shield<SEXP>(Rcpp::wrap(m)), Shield<SEXP>(Rcpp::wrap(n)));
+        }
+        if (rcpp_result_gen.inherits("interrupted-error"))
+            throw Rcpp::internal::InterruptedException();
+        if (Rcpp::internal::isLongjumpSentinel(rcpp_result_gen))
+            throw Rcpp::LongjumpException(rcpp_result_gen);
+        if (rcpp_result_gen.inherits("try-error"))
+            throw Rcpp::exception(Rcpp::as<std::string>(rcpp_result_gen).c_str());
+        return Rcpp::as<Rcpp::LogicalVector >(rcpp_result_gen);
+    }
+
+    inline std::vector<int> generate_n_primes(int n) {
+        typedef SEXP(*Ptr_generate_n_primes)(SEXP);
+        static Ptr_generate_n_primes p_generate_n_primes = NULL;
+        if (p_generate_n_primes == NULL) {
+            validateSignature("std::vector<int>(*generate_n_primes)(int)");
+            p_generate_n_primes = (Ptr_generate_n_primes)R_GetCCallable("primes", "_primes_generate_n_primes");
+        }
+        RObject rcpp_result_gen;
+        {
+            RNGScope RCPP_rngScope_gen;
+            rcpp_result_gen = p_generate_n_primes(Shield<SEXP>(Rcpp::wrap(n)));
+        }
+        if (rcpp_result_gen.inherits("interrupted-error"))
+            throw Rcpp::internal::InterruptedException();
+        if (Rcpp::internal::isLongjumpSentinel(rcpp_result_gen))
+            throw Rcpp::LongjumpException(rcpp_result_gen);
+        if (rcpp_result_gen.inherits("try-error"))
+            throw Rcpp::exception(Rcpp::as<std::string>(rcpp_result_gen).c_str());
+        return Rcpp::as<std::vector<int> >(rcpp_result_gen);
+    }
+
+    inline Rcpp::LogicalVector is_prime(const Rcpp::IntegerVector& x) {
+        typedef SEXP(*Ptr_is_prime)(SEXP);
+        static Ptr_is_prime p_is_prime = NULL;
+        if (p_is_prime == NULL) {
+            validateSignature("Rcpp::LogicalVector(*is_prime)(const Rcpp::IntegerVector&)");
+            p_is_prime = (Ptr_is_prime)R_GetCCallable("primes", "_primes_is_prime");
+        }
+        RObject rcpp_result_gen;
+        {
+            RNGScope RCPP_rngScope_gen;
+            rcpp_result_gen = p_is_prime(Shield<SEXP>(Rcpp::wrap(x)));
+        }
+        if (rcpp_result_gen.inherits("interrupted-error"))
+            throw Rcpp::internal::InterruptedException();
+        if (Rcpp::internal::isLongjumpSentinel(rcpp_result_gen))
+            throw Rcpp::LongjumpException(rcpp_result_gen);
+        if (rcpp_result_gen.inherits("try-error"))
+            throw Rcpp::exception(Rcpp::as<std::string>(rcpp_result_gen).c_str());
+        return Rcpp::as<Rcpp::LogicalVector >(rcpp_result_gen);
+    }
+
+    inline Rcpp::List k_tuple(int min, int max, std::vector<int> tuple) {
+        typedef SEXP(*Ptr_k_tuple)(SEXP,SEXP,SEXP);
+        static Ptr_k_tuple p_k_tuple = NULL;
+        if (p_k_tuple == NULL) {
+            validateSignature("Rcpp::List(*k_tuple)(int,int,std::vector<int>)");
+            p_k_tuple = (Ptr_k_tuple)R_GetCCallable("primes", "_primes_k_tuple");
+        }
+        RObject rcpp_result_gen;
+        {
+            RNGScope RCPP_rngScope_gen;
+            rcpp_result_gen = p_k_tuple(Shield<SEXP>(Rcpp::wrap(min)), Shield<SEXP>(Rcpp::wrap(max)), Shield<SEXP>(Rcpp::wrap(tuple)));
+        }
+        if (rcpp_result_gen.inherits("interrupted-error"))
+            throw Rcpp::internal::InterruptedException();
+        if (Rcpp::internal::isLongjumpSentinel(rcpp_result_gen))
+            throw Rcpp::LongjumpException(rcpp_result_gen);
+        if (rcpp_result_gen.inherits("try-error"))
+            throw Rcpp::exception(Rcpp::as<std::string>(rcpp_result_gen).c_str());
+        return Rcpp::as<Rcpp::List >(rcpp_result_gen);
+    }
+
+    inline Rcpp::List sexy_prime_triplets(int min, int max) {
+        typedef SEXP(*Ptr_sexy_prime_triplets)(SEXP,SEXP);
+        static Ptr_sexy_prime_triplets p_sexy_prime_triplets = NULL;
+        if (p_sexy_prime_triplets == NULL) {
+            validateSignature("Rcpp::List(*sexy_prime_triplets)(int,int)");
+            p_sexy_prime_triplets = (Ptr_sexy_prime_triplets)R_GetCCallable("primes", "_primes_sexy_prime_triplets");
+        }
+        RObject rcpp_result_gen;
+        {
+            RNGScope RCPP_rngScope_gen;
+            rcpp_result_gen = p_sexy_prime_triplets(Shield<SEXP>(Rcpp::wrap(min)), Shield<SEXP>(Rcpp::wrap(max)));
+        }
+        if (rcpp_result_gen.inherits("interrupted-error"))
+            throw Rcpp::internal::InterruptedException();
+        if (Rcpp::internal::isLongjumpSentinel(rcpp_result_gen))
+            throw Rcpp::LongjumpException(rcpp_result_gen);
+        if (rcpp_result_gen.inherits("try-error"))
+            throw Rcpp::exception(Rcpp::as<std::string>(rcpp_result_gen).c_str());
+        return Rcpp::as<Rcpp::List >(rcpp_result_gen);
+    }
+
+    inline Rcpp::IntegerVector next_prime(const Rcpp::IntegerVector& x) {
+        typedef SEXP(*Ptr_next_prime)(SEXP);
+        static Ptr_next_prime p_next_prime = NULL;
+        if (p_next_prime == NULL) {
+            validateSignature("Rcpp::IntegerVector(*next_prime)(const Rcpp::IntegerVector&)");
+            p_next_prime = (Ptr_next_prime)R_GetCCallable("primes", "_primes_next_prime");
+        }
+        RObject rcpp_result_gen;
+        {
+            RNGScope RCPP_rngScope_gen;
+            rcpp_result_gen = p_next_prime(Shield<SEXP>(Rcpp::wrap(x)));
+        }
+        if (rcpp_result_gen.inherits("interrupted-error"))
+            throw Rcpp::internal::InterruptedException();
+        if (Rcpp::internal::isLongjumpSentinel(rcpp_result_gen))
+            throw Rcpp::LongjumpException(rcpp_result_gen);
+        if (rcpp_result_gen.inherits("try-error"))
+            throw Rcpp::exception(Rcpp::as<std::string>(rcpp_result_gen).c_str());
+        return Rcpp::as<Rcpp::IntegerVector >(rcpp_result_gen);
+    }
+
+    inline Rcpp::IntegerVector prev_prime(const Rcpp::IntegerVector& x) {
+        typedef SEXP(*Ptr_prev_prime)(SEXP);
+        static Ptr_prev_prime p_prev_prime = NULL;
+        if (p_prev_prime == NULL) {
+            validateSignature("Rcpp::IntegerVector(*prev_prime)(const Rcpp::IntegerVector&)");
+            p_prev_prime = (Ptr_prev_prime)R_GetCCallable("primes", "_primes_prev_prime");
+        }
+        RObject rcpp_result_gen;
+        {
+            RNGScope RCPP_rngScope_gen;
+            rcpp_result_gen = p_prev_prime(Shield<SEXP>(Rcpp::wrap(x)));
+        }
+        if (rcpp_result_gen.inherits("interrupted-error"))
+            throw Rcpp::internal::InterruptedException();
+        if (Rcpp::internal::isLongjumpSentinel(rcpp_result_gen))
+            throw Rcpp::LongjumpException(rcpp_result_gen);
+        if (rcpp_result_gen.inherits("try-error"))
+            throw Rcpp::exception(Rcpp::as<std::string>(rcpp_result_gen).c_str());
+        return Rcpp::as<Rcpp::IntegerVector >(rcpp_result_gen);
+    }
+
+    inline Rcpp::IntegerVector nth_prime(const Rcpp::IntegerVector& x) {
+        typedef SEXP(*Ptr_nth_prime)(SEXP);
+        static Ptr_nth_prime p_nth_prime = NULL;
+        if (p_nth_prime == NULL) {
+            validateSignature("Rcpp::IntegerVector(*nth_prime)(const Rcpp::IntegerVector&)");
+            p_nth_prime = (Ptr_nth_prime)R_GetCCallable("primes", "_primes_nth_prime");
+        }
+        RObject rcpp_result_gen;
+        {
+            RNGScope RCPP_rngScope_gen;
+            rcpp_result_gen = p_nth_prime(Shield<SEXP>(Rcpp::wrap(x)));
+        }
+        if (rcpp_result_gen.inherits("interrupted-error"))
+            throw Rcpp::internal::InterruptedException();
+        if (Rcpp::internal::isLongjumpSentinel(rcpp_result_gen))
+            throw Rcpp::LongjumpException(rcpp_result_gen);
+        if (rcpp_result_gen.inherits("try-error"))
+            throw Rcpp::exception(Rcpp::as<std::string>(rcpp_result_gen).c_str());
+        return Rcpp::as<Rcpp::IntegerVector >(rcpp_result_gen);
+    }
+
+    inline int prime_count(int n, bool upper_bound) {
+        typedef SEXP(*Ptr_prime_count)(SEXP,SEXP);
+        static Ptr_prime_count p_prime_count = NULL;
+        if (p_prime_count == NULL) {
+            validateSignature("int(*prime_count)(int,bool)");
+            p_prime_count = (Ptr_prime_count)R_GetCCallable("primes", "_primes_prime_count");
+        }
+        RObject rcpp_result_gen;
+        {
+            RNGScope RCPP_rngScope_gen;
+            rcpp_result_gen = p_prime_count(Shield<SEXP>(Rcpp::wrap(n)), Shield<SEXP>(Rcpp::wrap(upper_bound)));
+        }
+        if (rcpp_result_gen.inherits("interrupted-error"))
+            throw Rcpp::internal::InterruptedException();
+        if (Rcpp::internal::isLongjumpSentinel(rcpp_result_gen))
+            throw Rcpp::LongjumpException(rcpp_result_gen);
+        if (rcpp_result_gen.inherits("try-error"))
+            throw Rcpp::exception(Rcpp::as<std::string>(rcpp_result_gen).c_str());
+        return Rcpp::as<int >(rcpp_result_gen);
+    }
+
+    inline int nth_prime_estimate(int n, bool upper_bound) {
+        typedef SEXP(*Ptr_nth_prime_estimate)(SEXP,SEXP);
+        static Ptr_nth_prime_estimate p_nth_prime_estimate = NULL;
+        if (p_nth_prime_estimate == NULL) {
+            validateSignature("int(*nth_prime_estimate)(int,bool)");
+            p_nth_prime_estimate = (Ptr_nth_prime_estimate)R_GetCCallable("primes", "_primes_nth_prime_estimate");
+        }
+        RObject rcpp_result_gen;
+        {
+            RNGScope RCPP_rngScope_gen;
+            rcpp_result_gen = p_nth_prime_estimate(Shield<SEXP>(Rcpp::wrap(n)), Shield<SEXP>(Rcpp::wrap(upper_bound)));
+        }
+        if (rcpp_result_gen.inherits("interrupted-error"))
+            throw Rcpp::internal::InterruptedException();
+        if (Rcpp::internal::isLongjumpSentinel(rcpp_result_gen))
+            throw Rcpp::LongjumpException(rcpp_result_gen);
+        if (rcpp_result_gen.inherits("try-error"))
+            throw Rcpp::exception(Rcpp::as<std::string>(rcpp_result_gen).c_str());
+        return Rcpp::as<int >(rcpp_result_gen);
+    }
+
+    inline Rcpp::List prime_factors(const Rcpp::IntegerVector& x) {
+        typedef SEXP(*Ptr_prime_factors)(SEXP);
+        static Ptr_prime_factors p_prime_factors = NULL;
+        if (p_prime_factors == NULL) {
+            validateSignature("Rcpp::List(*prime_factors)(const Rcpp::IntegerVector&)");
+            p_prime_factors = (Ptr_prime_factors)R_GetCCallable("primes", "_primes_prime_factors");
+        }
+        RObject rcpp_result_gen;
+        {
+            RNGScope RCPP_rngScope_gen;
+            rcpp_result_gen = p_prime_factors(Shield<SEXP>(Rcpp::wrap(x)));
+        }
+        if (rcpp_result_gen.inherits("interrupted-error"))
+            throw Rcpp::internal::InterruptedException();
+        if (Rcpp::internal::isLongjumpSentinel(rcpp_result_gen))
+            throw Rcpp::LongjumpException(rcpp_result_gen);
+        if (rcpp_result_gen.inherits("try-error"))
+            throw Rcpp::exception(Rcpp::as<std::string>(rcpp_result_gen).c_str());
+        return Rcpp::as<Rcpp::List >(rcpp_result_gen);
+    }
+
+    inline std::vector<int> generate_primes_(int min, int max) {
+        typedef SEXP(*Ptr_generate_primes_)(SEXP,SEXP);
+        static Ptr_generate_primes_ p_generate_primes_ = NULL;
+        if (p_generate_primes_ == NULL) {
+            validateSignature("std::vector<int>(*generate_primes_)(int,int)");
+            p_generate_primes_ = (Ptr_generate_primes_)R_GetCCallable("primes", "_primes_generate_primes_");
+        }
+        RObject rcpp_result_gen;
+        {
+            RNGScope RCPP_rngScope_gen;
+            rcpp_result_gen = p_generate_primes_(Shield<SEXP>(Rcpp::wrap(min)), Shield<SEXP>(Rcpp::wrap(max)));
+        }
+        if (rcpp_result_gen.inherits("interrupted-error"))
+            throw Rcpp::internal::InterruptedException();
+        if (Rcpp::internal::isLongjumpSentinel(rcpp_result_gen))
+            throw Rcpp::LongjumpException(rcpp_result_gen);
+        if (rcpp_result_gen.inherits("try-error"))
+            throw Rcpp::exception(Rcpp::as<std::string>(rcpp_result_gen).c_str());
+        return Rcpp::as<std::vector<int> >(rcpp_result_gen);
+    }
+
 }
 
 #endif // RCPP_primes_RCPPEXPORTS_H_GEN_

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -15,224 +15,674 @@ Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
 
 // gcd_
 int gcd_(int m, int n);
-RcppExport SEXP _primes_gcd_(SEXP mSEXP, SEXP nSEXP) {
+static SEXP _primes_gcd__try(SEXP mSEXP, SEXP nSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< int >::type m(mSEXP);
     Rcpp::traits::input_parameter< int >::type n(nSEXP);
     rcpp_result_gen = Rcpp::wrap(gcd_(m, n));
     return rcpp_result_gen;
-END_RCPP
+END_RCPP_RETURN_ERROR
+}
+RcppExport SEXP _primes_gcd_(SEXP mSEXP, SEXP nSEXP) {
+    SEXP rcpp_result_gen;
+    {
+        Rcpp::RNGScope rcpp_rngScope_gen;
+        rcpp_result_gen = PROTECT(_primes_gcd__try(mSEXP, nSEXP));
+    }
+    Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
+    if (rcpp_isInterrupt_gen) {
+        UNPROTECT(1);
+        Rf_onintr();
+    }
+    bool rcpp_isLongjump_gen = Rcpp::internal::isLongjumpSentinel(rcpp_result_gen);
+    if (rcpp_isLongjump_gen) {
+        Rcpp::internal::resumeJump(rcpp_result_gen);
+    }
+    Rboolean rcpp_isError_gen = Rf_inherits(rcpp_result_gen, "try-error");
+    if (rcpp_isError_gen) {
+        SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
+        UNPROTECT(1);
+        Rf_error(CHAR(rcpp_msgSEXP_gen));
+    }
+    UNPROTECT(1);
+    return rcpp_result_gen;
 }
 // Rgcd_
 int Rgcd_(const Rcpp::IntegerVector& x);
-RcppExport SEXP _primes_Rgcd_(SEXP xSEXP) {
+static SEXP _primes_Rgcd__try(SEXP xSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type x(xSEXP);
     rcpp_result_gen = Rcpp::wrap(Rgcd_(x));
     return rcpp_result_gen;
-END_RCPP
+END_RCPP_RETURN_ERROR
+}
+RcppExport SEXP _primes_Rgcd_(SEXP xSEXP) {
+    SEXP rcpp_result_gen;
+    {
+        Rcpp::RNGScope rcpp_rngScope_gen;
+        rcpp_result_gen = PROTECT(_primes_Rgcd__try(xSEXP));
+    }
+    Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
+    if (rcpp_isInterrupt_gen) {
+        UNPROTECT(1);
+        Rf_onintr();
+    }
+    bool rcpp_isLongjump_gen = Rcpp::internal::isLongjumpSentinel(rcpp_result_gen);
+    if (rcpp_isLongjump_gen) {
+        Rcpp::internal::resumeJump(rcpp_result_gen);
+    }
+    Rboolean rcpp_isError_gen = Rf_inherits(rcpp_result_gen, "try-error");
+    if (rcpp_isError_gen) {
+        SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
+        UNPROTECT(1);
+        Rf_error(CHAR(rcpp_msgSEXP_gen));
+    }
+    UNPROTECT(1);
+    return rcpp_result_gen;
 }
 // scm_
 int scm_(int m, int n);
-RcppExport SEXP _primes_scm_(SEXP mSEXP, SEXP nSEXP) {
+static SEXP _primes_scm__try(SEXP mSEXP, SEXP nSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< int >::type m(mSEXP);
     Rcpp::traits::input_parameter< int >::type n(nSEXP);
     rcpp_result_gen = Rcpp::wrap(scm_(m, n));
     return rcpp_result_gen;
-END_RCPP
+END_RCPP_RETURN_ERROR
+}
+RcppExport SEXP _primes_scm_(SEXP mSEXP, SEXP nSEXP) {
+    SEXP rcpp_result_gen;
+    {
+        Rcpp::RNGScope rcpp_rngScope_gen;
+        rcpp_result_gen = PROTECT(_primes_scm__try(mSEXP, nSEXP));
+    }
+    Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
+    if (rcpp_isInterrupt_gen) {
+        UNPROTECT(1);
+        Rf_onintr();
+    }
+    bool rcpp_isLongjump_gen = Rcpp::internal::isLongjumpSentinel(rcpp_result_gen);
+    if (rcpp_isLongjump_gen) {
+        Rcpp::internal::resumeJump(rcpp_result_gen);
+    }
+    Rboolean rcpp_isError_gen = Rf_inherits(rcpp_result_gen, "try-error");
+    if (rcpp_isError_gen) {
+        SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
+        UNPROTECT(1);
+        Rf_error(CHAR(rcpp_msgSEXP_gen));
+    }
+    UNPROTECT(1);
+    return rcpp_result_gen;
 }
 // Rscm_
 int Rscm_(const Rcpp::IntegerVector& x);
-RcppExport SEXP _primes_Rscm_(SEXP xSEXP) {
+static SEXP _primes_Rscm__try(SEXP xSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type x(xSEXP);
     rcpp_result_gen = Rcpp::wrap(Rscm_(x));
     return rcpp_result_gen;
-END_RCPP
+END_RCPP_RETURN_ERROR
+}
+RcppExport SEXP _primes_Rscm_(SEXP xSEXP) {
+    SEXP rcpp_result_gen;
+    {
+        Rcpp::RNGScope rcpp_rngScope_gen;
+        rcpp_result_gen = PROTECT(_primes_Rscm__try(xSEXP));
+    }
+    Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
+    if (rcpp_isInterrupt_gen) {
+        UNPROTECT(1);
+        Rf_onintr();
+    }
+    bool rcpp_isLongjump_gen = Rcpp::internal::isLongjumpSentinel(rcpp_result_gen);
+    if (rcpp_isLongjump_gen) {
+        Rcpp::internal::resumeJump(rcpp_result_gen);
+    }
+    Rboolean rcpp_isError_gen = Rf_inherits(rcpp_result_gen, "try-error");
+    if (rcpp_isError_gen) {
+        SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
+        UNPROTECT(1);
+        Rf_error(CHAR(rcpp_msgSEXP_gen));
+    }
+    UNPROTECT(1);
+    return rcpp_result_gen;
 }
 // gcd
 Rcpp::IntegerVector gcd(const Rcpp::IntegerVector& m, const Rcpp::IntegerVector& n);
-RcppExport SEXP _primes_gcd(SEXP mSEXP, SEXP nSEXP) {
+static SEXP _primes_gcd_try(SEXP mSEXP, SEXP nSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type m(mSEXP);
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type n(nSEXP);
     rcpp_result_gen = Rcpp::wrap(gcd(m, n));
     return rcpp_result_gen;
-END_RCPP
+END_RCPP_RETURN_ERROR
+}
+RcppExport SEXP _primes_gcd(SEXP mSEXP, SEXP nSEXP) {
+    SEXP rcpp_result_gen;
+    {
+        Rcpp::RNGScope rcpp_rngScope_gen;
+        rcpp_result_gen = PROTECT(_primes_gcd_try(mSEXP, nSEXP));
+    }
+    Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
+    if (rcpp_isInterrupt_gen) {
+        UNPROTECT(1);
+        Rf_onintr();
+    }
+    bool rcpp_isLongjump_gen = Rcpp::internal::isLongjumpSentinel(rcpp_result_gen);
+    if (rcpp_isLongjump_gen) {
+        Rcpp::internal::resumeJump(rcpp_result_gen);
+    }
+    Rboolean rcpp_isError_gen = Rf_inherits(rcpp_result_gen, "try-error");
+    if (rcpp_isError_gen) {
+        SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
+        UNPROTECT(1);
+        Rf_error(CHAR(rcpp_msgSEXP_gen));
+    }
+    UNPROTECT(1);
+    return rcpp_result_gen;
 }
 // scm
 Rcpp::IntegerVector scm(const Rcpp::IntegerVector& m, const Rcpp::IntegerVector& n);
-RcppExport SEXP _primes_scm(SEXP mSEXP, SEXP nSEXP) {
+static SEXP _primes_scm_try(SEXP mSEXP, SEXP nSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type m(mSEXP);
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type n(nSEXP);
     rcpp_result_gen = Rcpp::wrap(scm(m, n));
     return rcpp_result_gen;
-END_RCPP
+END_RCPP_RETURN_ERROR
+}
+RcppExport SEXP _primes_scm(SEXP mSEXP, SEXP nSEXP) {
+    SEXP rcpp_result_gen;
+    {
+        Rcpp::RNGScope rcpp_rngScope_gen;
+        rcpp_result_gen = PROTECT(_primes_scm_try(mSEXP, nSEXP));
+    }
+    Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
+    if (rcpp_isInterrupt_gen) {
+        UNPROTECT(1);
+        Rf_onintr();
+    }
+    bool rcpp_isLongjump_gen = Rcpp::internal::isLongjumpSentinel(rcpp_result_gen);
+    if (rcpp_isLongjump_gen) {
+        Rcpp::internal::resumeJump(rcpp_result_gen);
+    }
+    Rboolean rcpp_isError_gen = Rf_inherits(rcpp_result_gen, "try-error");
+    if (rcpp_isError_gen) {
+        SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
+        UNPROTECT(1);
+        Rf_error(CHAR(rcpp_msgSEXP_gen));
+    }
+    UNPROTECT(1);
+    return rcpp_result_gen;
 }
 // coprime
 Rcpp::LogicalVector coprime(const Rcpp::IntegerVector& m, const Rcpp::IntegerVector& n);
-RcppExport SEXP _primes_coprime(SEXP mSEXP, SEXP nSEXP) {
+static SEXP _primes_coprime_try(SEXP mSEXP, SEXP nSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type m(mSEXP);
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type n(nSEXP);
     rcpp_result_gen = Rcpp::wrap(coprime(m, n));
     return rcpp_result_gen;
-END_RCPP
+END_RCPP_RETURN_ERROR
+}
+RcppExport SEXP _primes_coprime(SEXP mSEXP, SEXP nSEXP) {
+    SEXP rcpp_result_gen;
+    {
+        Rcpp::RNGScope rcpp_rngScope_gen;
+        rcpp_result_gen = PROTECT(_primes_coprime_try(mSEXP, nSEXP));
+    }
+    Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
+    if (rcpp_isInterrupt_gen) {
+        UNPROTECT(1);
+        Rf_onintr();
+    }
+    bool rcpp_isLongjump_gen = Rcpp::internal::isLongjumpSentinel(rcpp_result_gen);
+    if (rcpp_isLongjump_gen) {
+        Rcpp::internal::resumeJump(rcpp_result_gen);
+    }
+    Rboolean rcpp_isError_gen = Rf_inherits(rcpp_result_gen, "try-error");
+    if (rcpp_isError_gen) {
+        SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
+        UNPROTECT(1);
+        Rf_error(CHAR(rcpp_msgSEXP_gen));
+    }
+    UNPROTECT(1);
+    return rcpp_result_gen;
 }
 // generate_n_primes
 std::vector<int> generate_n_primes(int n);
-RcppExport SEXP _primes_generate_n_primes(SEXP nSEXP) {
+static SEXP _primes_generate_n_primes_try(SEXP nSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< int >::type n(nSEXP);
     rcpp_result_gen = Rcpp::wrap(generate_n_primes(n));
     return rcpp_result_gen;
-END_RCPP
+END_RCPP_RETURN_ERROR
+}
+RcppExport SEXP _primes_generate_n_primes(SEXP nSEXP) {
+    SEXP rcpp_result_gen;
+    {
+        Rcpp::RNGScope rcpp_rngScope_gen;
+        rcpp_result_gen = PROTECT(_primes_generate_n_primes_try(nSEXP));
+    }
+    Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
+    if (rcpp_isInterrupt_gen) {
+        UNPROTECT(1);
+        Rf_onintr();
+    }
+    bool rcpp_isLongjump_gen = Rcpp::internal::isLongjumpSentinel(rcpp_result_gen);
+    if (rcpp_isLongjump_gen) {
+        Rcpp::internal::resumeJump(rcpp_result_gen);
+    }
+    Rboolean rcpp_isError_gen = Rf_inherits(rcpp_result_gen, "try-error");
+    if (rcpp_isError_gen) {
+        SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
+        UNPROTECT(1);
+        Rf_error(CHAR(rcpp_msgSEXP_gen));
+    }
+    UNPROTECT(1);
+    return rcpp_result_gen;
 }
 // is_prime
 Rcpp::LogicalVector is_prime(const Rcpp::IntegerVector& x);
-RcppExport SEXP _primes_is_prime(SEXP xSEXP) {
+static SEXP _primes_is_prime_try(SEXP xSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type x(xSEXP);
     rcpp_result_gen = Rcpp::wrap(is_prime(x));
     return rcpp_result_gen;
-END_RCPP
+END_RCPP_RETURN_ERROR
+}
+RcppExport SEXP _primes_is_prime(SEXP xSEXP) {
+    SEXP rcpp_result_gen;
+    {
+        Rcpp::RNGScope rcpp_rngScope_gen;
+        rcpp_result_gen = PROTECT(_primes_is_prime_try(xSEXP));
+    }
+    Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
+    if (rcpp_isInterrupt_gen) {
+        UNPROTECT(1);
+        Rf_onintr();
+    }
+    bool rcpp_isLongjump_gen = Rcpp::internal::isLongjumpSentinel(rcpp_result_gen);
+    if (rcpp_isLongjump_gen) {
+        Rcpp::internal::resumeJump(rcpp_result_gen);
+    }
+    Rboolean rcpp_isError_gen = Rf_inherits(rcpp_result_gen, "try-error");
+    if (rcpp_isError_gen) {
+        SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
+        UNPROTECT(1);
+        Rf_error(CHAR(rcpp_msgSEXP_gen));
+    }
+    UNPROTECT(1);
+    return rcpp_result_gen;
 }
 // k_tuple
 Rcpp::List k_tuple(int min, int max, std::vector<int> tuple);
-RcppExport SEXP _primes_k_tuple(SEXP minSEXP, SEXP maxSEXP, SEXP tupleSEXP) {
+static SEXP _primes_k_tuple_try(SEXP minSEXP, SEXP maxSEXP, SEXP tupleSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< int >::type min(minSEXP);
     Rcpp::traits::input_parameter< int >::type max(maxSEXP);
     Rcpp::traits::input_parameter< std::vector<int> >::type tuple(tupleSEXP);
     rcpp_result_gen = Rcpp::wrap(k_tuple(min, max, tuple));
     return rcpp_result_gen;
-END_RCPP
+END_RCPP_RETURN_ERROR
+}
+RcppExport SEXP _primes_k_tuple(SEXP minSEXP, SEXP maxSEXP, SEXP tupleSEXP) {
+    SEXP rcpp_result_gen;
+    {
+        Rcpp::RNGScope rcpp_rngScope_gen;
+        rcpp_result_gen = PROTECT(_primes_k_tuple_try(minSEXP, maxSEXP, tupleSEXP));
+    }
+    Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
+    if (rcpp_isInterrupt_gen) {
+        UNPROTECT(1);
+        Rf_onintr();
+    }
+    bool rcpp_isLongjump_gen = Rcpp::internal::isLongjumpSentinel(rcpp_result_gen);
+    if (rcpp_isLongjump_gen) {
+        Rcpp::internal::resumeJump(rcpp_result_gen);
+    }
+    Rboolean rcpp_isError_gen = Rf_inherits(rcpp_result_gen, "try-error");
+    if (rcpp_isError_gen) {
+        SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
+        UNPROTECT(1);
+        Rf_error(CHAR(rcpp_msgSEXP_gen));
+    }
+    UNPROTECT(1);
+    return rcpp_result_gen;
 }
 // sexy_prime_triplets
 Rcpp::List sexy_prime_triplets(int min, int max);
-RcppExport SEXP _primes_sexy_prime_triplets(SEXP minSEXP, SEXP maxSEXP) {
+static SEXP _primes_sexy_prime_triplets_try(SEXP minSEXP, SEXP maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< int >::type min(minSEXP);
     Rcpp::traits::input_parameter< int >::type max(maxSEXP);
     rcpp_result_gen = Rcpp::wrap(sexy_prime_triplets(min, max));
     return rcpp_result_gen;
-END_RCPP
+END_RCPP_RETURN_ERROR
+}
+RcppExport SEXP _primes_sexy_prime_triplets(SEXP minSEXP, SEXP maxSEXP) {
+    SEXP rcpp_result_gen;
+    {
+        Rcpp::RNGScope rcpp_rngScope_gen;
+        rcpp_result_gen = PROTECT(_primes_sexy_prime_triplets_try(minSEXP, maxSEXP));
+    }
+    Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
+    if (rcpp_isInterrupt_gen) {
+        UNPROTECT(1);
+        Rf_onintr();
+    }
+    bool rcpp_isLongjump_gen = Rcpp::internal::isLongjumpSentinel(rcpp_result_gen);
+    if (rcpp_isLongjump_gen) {
+        Rcpp::internal::resumeJump(rcpp_result_gen);
+    }
+    Rboolean rcpp_isError_gen = Rf_inherits(rcpp_result_gen, "try-error");
+    if (rcpp_isError_gen) {
+        SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
+        UNPROTECT(1);
+        Rf_error(CHAR(rcpp_msgSEXP_gen));
+    }
+    UNPROTECT(1);
+    return rcpp_result_gen;
 }
 // next_prime
 Rcpp::IntegerVector next_prime(const Rcpp::IntegerVector& x);
-RcppExport SEXP _primes_next_prime(SEXP xSEXP) {
+static SEXP _primes_next_prime_try(SEXP xSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type x(xSEXP);
     rcpp_result_gen = Rcpp::wrap(next_prime(x));
     return rcpp_result_gen;
-END_RCPP
+END_RCPP_RETURN_ERROR
+}
+RcppExport SEXP _primes_next_prime(SEXP xSEXP) {
+    SEXP rcpp_result_gen;
+    {
+        Rcpp::RNGScope rcpp_rngScope_gen;
+        rcpp_result_gen = PROTECT(_primes_next_prime_try(xSEXP));
+    }
+    Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
+    if (rcpp_isInterrupt_gen) {
+        UNPROTECT(1);
+        Rf_onintr();
+    }
+    bool rcpp_isLongjump_gen = Rcpp::internal::isLongjumpSentinel(rcpp_result_gen);
+    if (rcpp_isLongjump_gen) {
+        Rcpp::internal::resumeJump(rcpp_result_gen);
+    }
+    Rboolean rcpp_isError_gen = Rf_inherits(rcpp_result_gen, "try-error");
+    if (rcpp_isError_gen) {
+        SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
+        UNPROTECT(1);
+        Rf_error(CHAR(rcpp_msgSEXP_gen));
+    }
+    UNPROTECT(1);
+    return rcpp_result_gen;
 }
 // prev_prime
 Rcpp::IntegerVector prev_prime(const Rcpp::IntegerVector& x);
-RcppExport SEXP _primes_prev_prime(SEXP xSEXP) {
+static SEXP _primes_prev_prime_try(SEXP xSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type x(xSEXP);
     rcpp_result_gen = Rcpp::wrap(prev_prime(x));
     return rcpp_result_gen;
-END_RCPP
+END_RCPP_RETURN_ERROR
+}
+RcppExport SEXP _primes_prev_prime(SEXP xSEXP) {
+    SEXP rcpp_result_gen;
+    {
+        Rcpp::RNGScope rcpp_rngScope_gen;
+        rcpp_result_gen = PROTECT(_primes_prev_prime_try(xSEXP));
+    }
+    Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
+    if (rcpp_isInterrupt_gen) {
+        UNPROTECT(1);
+        Rf_onintr();
+    }
+    bool rcpp_isLongjump_gen = Rcpp::internal::isLongjumpSentinel(rcpp_result_gen);
+    if (rcpp_isLongjump_gen) {
+        Rcpp::internal::resumeJump(rcpp_result_gen);
+    }
+    Rboolean rcpp_isError_gen = Rf_inherits(rcpp_result_gen, "try-error");
+    if (rcpp_isError_gen) {
+        SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
+        UNPROTECT(1);
+        Rf_error(CHAR(rcpp_msgSEXP_gen));
+    }
+    UNPROTECT(1);
+    return rcpp_result_gen;
 }
 // nth_prime
 Rcpp::IntegerVector nth_prime(const Rcpp::IntegerVector& x);
-RcppExport SEXP _primes_nth_prime(SEXP xSEXP) {
+static SEXP _primes_nth_prime_try(SEXP xSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type x(xSEXP);
     rcpp_result_gen = Rcpp::wrap(nth_prime(x));
     return rcpp_result_gen;
-END_RCPP
+END_RCPP_RETURN_ERROR
+}
+RcppExport SEXP _primes_nth_prime(SEXP xSEXP) {
+    SEXP rcpp_result_gen;
+    {
+        Rcpp::RNGScope rcpp_rngScope_gen;
+        rcpp_result_gen = PROTECT(_primes_nth_prime_try(xSEXP));
+    }
+    Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
+    if (rcpp_isInterrupt_gen) {
+        UNPROTECT(1);
+        Rf_onintr();
+    }
+    bool rcpp_isLongjump_gen = Rcpp::internal::isLongjumpSentinel(rcpp_result_gen);
+    if (rcpp_isLongjump_gen) {
+        Rcpp::internal::resumeJump(rcpp_result_gen);
+    }
+    Rboolean rcpp_isError_gen = Rf_inherits(rcpp_result_gen, "try-error");
+    if (rcpp_isError_gen) {
+        SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
+        UNPROTECT(1);
+        Rf_error(CHAR(rcpp_msgSEXP_gen));
+    }
+    UNPROTECT(1);
+    return rcpp_result_gen;
 }
 // prime_count
 int prime_count(int n, bool upper_bound);
-RcppExport SEXP _primes_prime_count(SEXP nSEXP, SEXP upper_boundSEXP) {
+static SEXP _primes_prime_count_try(SEXP nSEXP, SEXP upper_boundSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< int >::type n(nSEXP);
     Rcpp::traits::input_parameter< bool >::type upper_bound(upper_boundSEXP);
     rcpp_result_gen = Rcpp::wrap(prime_count(n, upper_bound));
     return rcpp_result_gen;
-END_RCPP
+END_RCPP_RETURN_ERROR
+}
+RcppExport SEXP _primes_prime_count(SEXP nSEXP, SEXP upper_boundSEXP) {
+    SEXP rcpp_result_gen;
+    {
+        Rcpp::RNGScope rcpp_rngScope_gen;
+        rcpp_result_gen = PROTECT(_primes_prime_count_try(nSEXP, upper_boundSEXP));
+    }
+    Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
+    if (rcpp_isInterrupt_gen) {
+        UNPROTECT(1);
+        Rf_onintr();
+    }
+    bool rcpp_isLongjump_gen = Rcpp::internal::isLongjumpSentinel(rcpp_result_gen);
+    if (rcpp_isLongjump_gen) {
+        Rcpp::internal::resumeJump(rcpp_result_gen);
+    }
+    Rboolean rcpp_isError_gen = Rf_inherits(rcpp_result_gen, "try-error");
+    if (rcpp_isError_gen) {
+        SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
+        UNPROTECT(1);
+        Rf_error(CHAR(rcpp_msgSEXP_gen));
+    }
+    UNPROTECT(1);
+    return rcpp_result_gen;
 }
 // nth_prime_estimate
 int nth_prime_estimate(int n, bool upper_bound);
-RcppExport SEXP _primes_nth_prime_estimate(SEXP nSEXP, SEXP upper_boundSEXP) {
+static SEXP _primes_nth_prime_estimate_try(SEXP nSEXP, SEXP upper_boundSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< int >::type n(nSEXP);
     Rcpp::traits::input_parameter< bool >::type upper_bound(upper_boundSEXP);
     rcpp_result_gen = Rcpp::wrap(nth_prime_estimate(n, upper_bound));
     return rcpp_result_gen;
-END_RCPP
+END_RCPP_RETURN_ERROR
+}
+RcppExport SEXP _primes_nth_prime_estimate(SEXP nSEXP, SEXP upper_boundSEXP) {
+    SEXP rcpp_result_gen;
+    {
+        Rcpp::RNGScope rcpp_rngScope_gen;
+        rcpp_result_gen = PROTECT(_primes_nth_prime_estimate_try(nSEXP, upper_boundSEXP));
+    }
+    Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
+    if (rcpp_isInterrupt_gen) {
+        UNPROTECT(1);
+        Rf_onintr();
+    }
+    bool rcpp_isLongjump_gen = Rcpp::internal::isLongjumpSentinel(rcpp_result_gen);
+    if (rcpp_isLongjump_gen) {
+        Rcpp::internal::resumeJump(rcpp_result_gen);
+    }
+    Rboolean rcpp_isError_gen = Rf_inherits(rcpp_result_gen, "try-error");
+    if (rcpp_isError_gen) {
+        SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
+        UNPROTECT(1);
+        Rf_error(CHAR(rcpp_msgSEXP_gen));
+    }
+    UNPROTECT(1);
+    return rcpp_result_gen;
 }
 // prime_factors
 Rcpp::List prime_factors(const Rcpp::IntegerVector& x);
-RcppExport SEXP _primes_prime_factors(SEXP xSEXP) {
+static SEXP _primes_prime_factors_try(SEXP xSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type x(xSEXP);
     rcpp_result_gen = Rcpp::wrap(prime_factors(x));
     return rcpp_result_gen;
-END_RCPP
+END_RCPP_RETURN_ERROR
+}
+RcppExport SEXP _primes_prime_factors(SEXP xSEXP) {
+    SEXP rcpp_result_gen;
+    {
+        Rcpp::RNGScope rcpp_rngScope_gen;
+        rcpp_result_gen = PROTECT(_primes_prime_factors_try(xSEXP));
+    }
+    Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
+    if (rcpp_isInterrupt_gen) {
+        UNPROTECT(1);
+        Rf_onintr();
+    }
+    bool rcpp_isLongjump_gen = Rcpp::internal::isLongjumpSentinel(rcpp_result_gen);
+    if (rcpp_isLongjump_gen) {
+        Rcpp::internal::resumeJump(rcpp_result_gen);
+    }
+    Rboolean rcpp_isError_gen = Rf_inherits(rcpp_result_gen, "try-error");
+    if (rcpp_isError_gen) {
+        SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
+        UNPROTECT(1);
+        Rf_error(CHAR(rcpp_msgSEXP_gen));
+    }
+    UNPROTECT(1);
+    return rcpp_result_gen;
 }
 // generate_primes_
 std::vector<int> generate_primes_(int min, int max);
-RcppExport SEXP _primes_generate_primes_(SEXP minSEXP, SEXP maxSEXP) {
+static SEXP _primes_generate_primes__try(SEXP minSEXP, SEXP maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< int >::type min(minSEXP);
     Rcpp::traits::input_parameter< int >::type max(maxSEXP);
     rcpp_result_gen = Rcpp::wrap(generate_primes_(min, max));
     return rcpp_result_gen;
-END_RCPP
+END_RCPP_RETURN_ERROR
+}
+RcppExport SEXP _primes_generate_primes_(SEXP minSEXP, SEXP maxSEXP) {
+    SEXP rcpp_result_gen;
+    {
+        Rcpp::RNGScope rcpp_rngScope_gen;
+        rcpp_result_gen = PROTECT(_primes_generate_primes__try(minSEXP, maxSEXP));
+    }
+    Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
+    if (rcpp_isInterrupt_gen) {
+        UNPROTECT(1);
+        Rf_onintr();
+    }
+    bool rcpp_isLongjump_gen = Rcpp::internal::isLongjumpSentinel(rcpp_result_gen);
+    if (rcpp_isLongjump_gen) {
+        Rcpp::internal::resumeJump(rcpp_result_gen);
+    }
+    Rboolean rcpp_isError_gen = Rf_inherits(rcpp_result_gen, "try-error");
+    if (rcpp_isError_gen) {
+        SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
+        UNPROTECT(1);
+        Rf_error(CHAR(rcpp_msgSEXP_gen));
+    }
+    UNPROTECT(1);
+    return rcpp_result_gen;
 }
 
 // validate (ensure exported C++ functions exist before calling them)
 static int _primes_RcppExport_validate(const char* sig) { 
     static std::set<std::string> signatures;
     if (signatures.empty()) {
+        signatures.insert("int(*gcd_)(int,int)");
+        signatures.insert("int(*Rgcd_)(const Rcpp::IntegerVector&)");
+        signatures.insert("int(*scm_)(int,int)");
+        signatures.insert("int(*Rscm_)(const Rcpp::IntegerVector&)");
+        signatures.insert("Rcpp::IntegerVector(*gcd)(const Rcpp::IntegerVector&,const Rcpp::IntegerVector&)");
+        signatures.insert("Rcpp::IntegerVector(*scm)(const Rcpp::IntegerVector&,const Rcpp::IntegerVector&)");
+        signatures.insert("Rcpp::LogicalVector(*coprime)(const Rcpp::IntegerVector&,const Rcpp::IntegerVector&)");
+        signatures.insert("std::vector<int>(*generate_n_primes)(int)");
+        signatures.insert("Rcpp::LogicalVector(*is_prime)(const Rcpp::IntegerVector&)");
+        signatures.insert("Rcpp::List(*k_tuple)(int,int,std::vector<int>)");
+        signatures.insert("Rcpp::List(*sexy_prime_triplets)(int,int)");
+        signatures.insert("Rcpp::IntegerVector(*next_prime)(const Rcpp::IntegerVector&)");
+        signatures.insert("Rcpp::IntegerVector(*prev_prime)(const Rcpp::IntegerVector&)");
+        signatures.insert("Rcpp::IntegerVector(*nth_prime)(const Rcpp::IntegerVector&)");
+        signatures.insert("int(*prime_count)(int,bool)");
+        signatures.insert("int(*nth_prime_estimate)(int,bool)");
+        signatures.insert("Rcpp::List(*prime_factors)(const Rcpp::IntegerVector&)");
+        signatures.insert("std::vector<int>(*generate_primes_)(int,int)");
     }
     return signatures.find(sig) != signatures.end();
 }
 
 // registerCCallable (register entry points for exported C++ functions)
 RcppExport SEXP _primes_RcppExport_registerCCallable() { 
+    R_RegisterCCallable("primes", "_primes_gcd_", (DL_FUNC)_primes_gcd__try);
+    R_RegisterCCallable("primes", "_primes_Rgcd_", (DL_FUNC)_primes_Rgcd__try);
+    R_RegisterCCallable("primes", "_primes_scm_", (DL_FUNC)_primes_scm__try);
+    R_RegisterCCallable("primes", "_primes_Rscm_", (DL_FUNC)_primes_Rscm__try);
+    R_RegisterCCallable("primes", "_primes_gcd", (DL_FUNC)_primes_gcd_try);
+    R_RegisterCCallable("primes", "_primes_scm", (DL_FUNC)_primes_scm_try);
+    R_RegisterCCallable("primes", "_primes_coprime", (DL_FUNC)_primes_coprime_try);
+    R_RegisterCCallable("primes", "_primes_generate_n_primes", (DL_FUNC)_primes_generate_n_primes_try);
+    R_RegisterCCallable("primes", "_primes_is_prime", (DL_FUNC)_primes_is_prime_try);
+    R_RegisterCCallable("primes", "_primes_k_tuple", (DL_FUNC)_primes_k_tuple_try);
+    R_RegisterCCallable("primes", "_primes_sexy_prime_triplets", (DL_FUNC)_primes_sexy_prime_triplets_try);
+    R_RegisterCCallable("primes", "_primes_next_prime", (DL_FUNC)_primes_next_prime_try);
+    R_RegisterCCallable("primes", "_primes_prev_prime", (DL_FUNC)_primes_prev_prime_try);
+    R_RegisterCCallable("primes", "_primes_nth_prime", (DL_FUNC)_primes_nth_prime_try);
+    R_RegisterCCallable("primes", "_primes_prime_count", (DL_FUNC)_primes_prime_count_try);
+    R_RegisterCCallable("primes", "_primes_nth_prime_estimate", (DL_FUNC)_primes_nth_prime_estimate_try);
+    R_RegisterCCallable("primes", "_primes_prime_factors", (DL_FUNC)_primes_prime_factors_try);
+    R_RegisterCCallable("primes", "_primes_generate_primes_", (DL_FUNC)_primes_generate_primes__try);
     R_RegisterCCallable("primes", "_primes_RcppExport_validate", (DL_FUNC)_primes_RcppExport_validate);
     return R_NilValue;
 }

--- a/src/gcd.cpp
+++ b/src/gcd.cpp
@@ -3,6 +3,7 @@
 #include <numeric>    // accumulate
 #include <cstdlib>    // abs
 
+// [[Rcpp::interfaces(r, cpp)]]
 
 // [[Rcpp::export]]
 int gcd_(int m, int n) {

--- a/src/generate_n_primes.cpp
+++ b/src/generate_n_primes.cpp
@@ -3,6 +3,8 @@
 
 #include "primes.h"
 
+// [[Rcpp::interfaces(r, cpp)]]
+
 //' @rdname generate_primes
 //' @export
 // [[Rcpp::export]]

--- a/src/is_prime.cpp
+++ b/src/is_prime.cpp
@@ -1,6 +1,8 @@
 #include <Rcpp.h>
 #include <cmath>
 
+// [[Rcpp::interfaces(r, cpp)]]
+
 bool is_prime_(int x) {
 
   if (x < 4)

--- a/src/k_tuple.cpp
+++ b/src/k_tuple.cpp
@@ -4,6 +4,8 @@
 
 #include "primes.h"
 
+// [[Rcpp::interfaces(r, cpp)]]
+
 static std::vector<int>::iterator
 forward_search(std::vector<int>::iterator first,
                std::vector<int>::iterator last,

--- a/src/next_prime.cpp
+++ b/src/next_prime.cpp
@@ -2,6 +2,8 @@
 
 #include "primes.h"
 
+// [[Rcpp::interfaces(r, cpp)]]
+
 //' Find the Next and Previous Prime Numbers
 //'
 //' Find the next prime numbers or previous prime numbers over a vector.

--- a/src/nth_prime.cpp
+++ b/src/nth_prime.cpp
@@ -3,6 +3,8 @@
 
 #include "primes.h"
 
+// [[Rcpp::interfaces(r, cpp)]]
+
 //' Get the n-th Prime from the Sequence of Primes.
 //'
 //' Get the n-th prime, \eqn{p_n}, in the sequence of primes.

--- a/src/prime_count.cpp
+++ b/src/prime_count.cpp
@@ -1,6 +1,8 @@
 #include <Rcpp.h>
 #include <cmath>
 
+// [[Rcpp::interfaces(r, cpp)]]
+
 static const double prime_count_c = 30 * log((double)113) / 113;
 
 //' @rdname prime_count

--- a/src/prime_factors.cpp
+++ b/src/prime_factors.cpp
@@ -5,6 +5,8 @@
 
 #include "primes.h"
 
+// [[Rcpp::interfaces(r, cpp)]]
+
 static Rcpp::IntegerVector prime_factors_(int n, const std::vector<int> &primes) {
   Rcpp::IntegerVector factors;
 

--- a/src/primes.h
+++ b/src/primes.h
@@ -4,9 +4,6 @@
 #include <Rcpp.h>
 #include <vector>
 
-// [[Rcpp::interfaces(r, cpp)]]
-// [[Rcpp::plugins(cpp11)]]
-
 std::vector<int> generate_primes_(int min, int max);
 std::vector<int> generate_n_primes(int n);
 Rcpp::IntegerVector nth_prime(const Rcpp::IntegerVector& x);

--- a/src/sieve.cpp
+++ b/src/sieve.cpp
@@ -5,6 +5,8 @@
 
 #include "primes.h"
 
+// [[Rcpp::interfaces(r, cpp)]]
+
 static inline int num2index(int x) { return (x - 3) / 2; }
 
 static inline int index2num(int x) { return (x * 2) + 3; }


### PR DESCRIPTION
This is due to the removal of `SystemRequiremens` entry and was accidentally omitted from ironholds#10

Details behind the change found [here](https://gist.github.com/wch/849ca79c9416795d99c48cc06a44ca1e)