### PR TITLE
Addressing clang-UBSan Undefined Behavior Memcheck

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,4 @@
 ^docs$
 ^pkgdown$
 ^\.github$
+^cran-comments\.md$

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ vignettes/*.html
 vignettes/*.pdf
 .Rproj.user
 docs
+*.bak

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: primes
 Type: Package
 Title: Fast Functions for Prime Numbers
-Version: 1.5.0
-Date: 2023-10-02
+Version: 1.5.1
+Date: 2023-10-12
 Authors@R: c(
     person("Os", "Keyes", email = "ironholds@gmail.com", role = c("aut", "cre")),
     person("Paul", "Egeler", email = "paulegeler@gmail.com", role = c("aut"), comment = c(ORCID = "0000-0001-6948-9498"))

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,57 @@
+## Version 1.5.1
+
+### Purpose
+
+This patch release addresses the [clang-UBSan finding](https://www.stats.ox.ac.uk/pub/bdr/memtests/clang-UBSAN/primes/tests/testthat.Rout)
+wherein an implicit conversion from `double` to `int` could result in
+undefined behavior when the floating point value cannot be represented as an integer, _ie_, the value is `-nan`. The UBSan test output is below.
+
+### Solution
+
+Using the [rocker/r-devel-ubsan-clang](https://hub.docker.com/r/rocker/r-devel-ubsan-clang)
+Docker container, I was able to reproduce the bug.
+
+```
+# RD -q
+> version
+               _                                                 
+platform       x86_64-pc-linux-gnu                               
+arch           x86_64                                            
+os             linux-gnu                                         
+system         x86_64, linux-gnu                                 
+status         Under development (unstable)                      
+major          4                                                 
+minor          3.0                                               
+year           2022                                              
+month          09                                                
+day            19                                                
+svn rev        82882                                             
+language       R                                                 
+version.string R Under development (unstable) (2022-09-19 r82882)
+nickname       Unsuffered Consequences                           
+> packageVersion("primes")
+[1] ‘1.5.0’
+> source("testthat.R")
+prime_factors.cpp:13:14: runtime error: -nan is outside the range of representable values of type 'int'
+SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior prime_factors.cpp:13:14 in 
+[ FAIL 0 | WARN 0 | SKIP 0 | PASS 62 ]
+
+```
+
+A patch was created to prevent a domain error when calling `std::sqrt`. After
+applying the patch, recompiling, and reinstalling, the runtime error is no longer
+encountered.
+
+```
+# RD -q
+> packageVersion("primes")
+[1] ‘1.5.1’
+> source("testthat.R")
+[ FAIL 0 | WARN 0 | SKIP 0 | PASS 62 ]
+```
+
+### R CMD check results
+
+0 errors ✔ | 0 warnings ✔ | 0 notes ✔
+
+R CMD check succeeded

--- a/src/prime_factors.cpp
+++ b/src/prime_factors.cpp
@@ -1,16 +1,22 @@
 #include <Rcpp.h>
-#include <algorithm>  // max_element
 #include <cmath>      // sqrt
 #include <vector>
 
 #include "primes.h"
 
+using std::sqrt;
+
 // [[Rcpp::interfaces(r, cpp)]]
 
 static Rcpp::IntegerVector prime_factors_(int n, const std::vector<int> &primes) {
+  if (n < 2)
+    return {};
+
   Rcpp::IntegerVector factors;
 
-  int stop = sqrt((double)n);
+  // TODO: static_cast<double>() no longer necessary. Overload from integer
+  //       supported since C++11.
+  int stop = sqrt(static_cast<double>(n));
   for (auto p = primes.begin(); p != primes.end() && *p <= stop && n > 1; ++p) {
     while (n % *p == 0) {
       factors.push_back(*p);
@@ -58,8 +64,8 @@ Rcpp::List prime_factors(const Rcpp::IntegerVector &x) {
 
   Rcpp::List out(x.size());
   auto it = out.begin();
-  int max = *std::max_element(x.begin(), x.end());
-  auto primes = generate_primes_(2, max > 8 ? sqrt((double)max) : 2);
+  int max = Rcpp::algorithm::max_nona(x.begin(), x.end());
+  auto primes = generate_primes_(2, max > 8 ? sqrt(static_cast<double>(max)) : 2);
 
   for (auto n : x) {
     *(it++) = Rcpp::IntegerVector::is_na(n)

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+failures/

--- a/tests/testthat/test_prime_factors.R
+++ b/tests/testthat/test_prime_factors.R
@@ -3,8 +3,9 @@ context("Prime factors")
 test_that("Create a vector of factors", {
   expect_equal(prime_factors(2), list(2))
   expect_equal(
-    prime_factors(c(-1:2, 7:11)),
+    prime_factors(c(-2:2, 7:11)),
     list(
+      integer(0),     # -2
       integer(0),     # -1
       integer(0),     #  0
       integer(0),     #  1
@@ -26,6 +27,10 @@ test_that("NAs are handled properly", {
   expect_equal(
     prime_factors(c(NA, 1, 3)),
     list(as.integer(NA), integer(0), 3L)
+  )
+  expect_equal(
+    prime_factors(c(NA, 120)),
+    list(as.integer(NA), c(2L, 2L, 2L, 3L, 5L))
   )
 })
 


### PR DESCRIPTION
## Purpose

This PR fixes undefined behavior uncovered by the [CRAN clang-UBSan memcheck](https://www.stats.ox.ac.uk/pub/bdr/memtests/clang-UBSAN/primes/tests/testthat.Rout) raised earlier this week. _cran_comments.md_ goes into detail on how this bug can be reproduced.

## Explanation

The bug was found and fixed in _src/prime_factors.cpp_. The `prime_factors_` helper function takes an `int` input that is cast to `double`, passed to `std::sqrt`, then cast back to `int`. The [return value](https://en.cppreference.com/w/cpp/numeric/math/sqrt#Return_value) of `std::sqrt` when encountering domain error (input < 0) is undefined but expected to be `NaN`, which cannot be represented when cast back to `int`. Thus we have undefined behavior. 

## The Fix

I have added an early exit for values that would cause a domain error.
