### PR TITLE
Fixing -Wformat-security warning in RcppExports

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,4 @@
 ^pkgdown$
 ^\.github$
 ^cran-comments\.md$
+^.vscode$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: primes
 Type: Package
 Title: Fast Functions for Prime Numbers
-Version: 1.5.1
-Date: 2023-10-12
+Version: 1.5.2
+Date: 2023-12-14
 Authors@R: c(
     person("Os", "Keyes", email = "ironholds@gmail.com", role = c("aut", "cre")),
     person("Paul", "Egeler", email = "paulegeler@gmail.com", role = c("aut"), comment = c(ORCID = "0000-0001-6948-9498"))

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -43,7 +43,7 @@ RcppExport SEXP _primes_gcd_(SEXP mSEXP, SEXP nSEXP) {
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error(CHAR(rcpp_msgSEXP_gen));
+        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;
@@ -77,7 +77,7 @@ RcppExport SEXP _primes_Rgcd_(SEXP xSEXP) {
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error(CHAR(rcpp_msgSEXP_gen));
+        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;
@@ -112,7 +112,7 @@ RcppExport SEXP _primes_scm_(SEXP mSEXP, SEXP nSEXP) {
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error(CHAR(rcpp_msgSEXP_gen));
+        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;
@@ -146,7 +146,7 @@ RcppExport SEXP _primes_Rscm_(SEXP xSEXP) {
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error(CHAR(rcpp_msgSEXP_gen));
+        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;
@@ -181,7 +181,7 @@ RcppExport SEXP _primes_gcd(SEXP mSEXP, SEXP nSEXP) {
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error(CHAR(rcpp_msgSEXP_gen));
+        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;
@@ -216,7 +216,7 @@ RcppExport SEXP _primes_scm(SEXP mSEXP, SEXP nSEXP) {
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error(CHAR(rcpp_msgSEXP_gen));
+        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;
@@ -251,7 +251,7 @@ RcppExport SEXP _primes_coprime(SEXP mSEXP, SEXP nSEXP) {
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error(CHAR(rcpp_msgSEXP_gen));
+        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;
@@ -285,7 +285,7 @@ RcppExport SEXP _primes_generate_n_primes(SEXP nSEXP) {
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error(CHAR(rcpp_msgSEXP_gen));
+        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;
@@ -319,7 +319,7 @@ RcppExport SEXP _primes_is_prime(SEXP xSEXP) {
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error(CHAR(rcpp_msgSEXP_gen));
+        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;
@@ -355,7 +355,7 @@ RcppExport SEXP _primes_k_tuple(SEXP minSEXP, SEXP maxSEXP, SEXP tupleSEXP) {
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error(CHAR(rcpp_msgSEXP_gen));
+        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;
@@ -390,7 +390,7 @@ RcppExport SEXP _primes_sexy_prime_triplets(SEXP minSEXP, SEXP maxSEXP) {
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error(CHAR(rcpp_msgSEXP_gen));
+        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;
@@ -424,7 +424,7 @@ RcppExport SEXP _primes_next_prime(SEXP xSEXP) {
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error(CHAR(rcpp_msgSEXP_gen));
+        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;
@@ -458,7 +458,7 @@ RcppExport SEXP _primes_prev_prime(SEXP xSEXP) {
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error(CHAR(rcpp_msgSEXP_gen));
+        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;
@@ -492,7 +492,7 @@ RcppExport SEXP _primes_nth_prime(SEXP xSEXP) {
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error(CHAR(rcpp_msgSEXP_gen));
+        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;
@@ -527,7 +527,7 @@ RcppExport SEXP _primes_prime_count(SEXP nSEXP, SEXP upper_boundSEXP) {
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error(CHAR(rcpp_msgSEXP_gen));
+        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;
@@ -562,7 +562,7 @@ RcppExport SEXP _primes_nth_prime_estimate(SEXP nSEXP, SEXP upper_boundSEXP) {
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error(CHAR(rcpp_msgSEXP_gen));
+        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;
@@ -596,7 +596,7 @@ RcppExport SEXP _primes_prime_factors(SEXP xSEXP) {
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error(CHAR(rcpp_msgSEXP_gen));
+        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;
@@ -631,7 +631,7 @@ RcppExport SEXP _primes_generate_primes_(SEXP minSEXP, SEXP maxSEXP) {
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error(CHAR(rcpp_msgSEXP_gen));
+        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;


### PR DESCRIPTION
## The Problem

A recent [CRAN check](https://cran.r-project.org/web/checks/check_results_primes.html) has found some warnings.

```
Version: 1.5.1
Check: whether package can be installed
Result: WARN
  Found the following significant warnings:
    RcppExports.cpp:46:18: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
    RcppExports.cpp:80:18: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
    RcppExports.cpp:115:18: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
    RcppExports.cpp:149:18: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
    RcppExports.cpp:184:18: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
    RcppExports.cpp:219:18: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
    RcppExports.cpp:254:18: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
    RcppExports.cpp:288:18: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
    RcppExports.cpp:322:18: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
    RcppExports.cpp:358:18: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
    RcppExports.cpp:393:18: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
    RcppExports.cpp:427:18: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
    RcppExports.cpp:461:18: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
    RcppExports.cpp:495:18: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
    RcppExports.cpp:530:18: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
    RcppExports.cpp:565:18: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
    RcppExports.cpp:599:18: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
    RcppExports.cpp:634:18: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
  See ‘/home/hornik/tmp/R.check/r-devel-clang/Work/PKGS/primes.Rcheck/00install.out’ for details.
  * used C++ compiler: ‘Debian clang version 17.0.5 (1)’
Flavor: [r-devel-linux-x86_64-debian-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/primes-00check.html)
```

Reproduced locally using [rhub/debian-clang-devel](https://hub.docker.com/r/rhub/debian-clang-devel).

## The Fix

Following [instructions](https://stackoverflow.com/a/77567362/8617947) from Dirk Eddelbuettel on Stack Overflow and linked GH issues, I rebuilt the _RcppExports.cpp_ file using `Rcpp::compileAttributes()`. I then built and checked on [rhub/debian-clang-devel](https://hub.docker.com/r/rhub/debian-clang-devel) to confirm the warning is no longer present.