### PR TITLE
Preventing debug files from inclusion in build

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,4 @@
 ^cran-comments\.md$
 ^.vscode$
 ^tests/failures$
+^Dockerfile$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,4 @@
 ^\.github$
 ^cran-comments\.md$
 ^.vscode$
+^tests/failures$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: primes
 Type: Package
 Title: Fast Functions for Prime Numbers
-Version: 1.6.0
-Date: 2023-12-30
+Version: 1.6.1
+Date: 2025-01-28
 Authors@R: c(
     person("Os", "Keyes", email = "ironholds@gmail.com", role = c("aut", "cre")),
     person("Paul", "Egeler", email = "paulegeler@gmail.com", role = c("aut"), comment = c(ORCID = "0000-0001-6948-9498"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,8 +4,8 @@ Title: Fast Functions for Prime Numbers
 Version: 1.6.1
 Date: 2025-01-28
 Authors@R: c(
-    person("Os", "Keyes", email = "ironholds@gmail.com", role = c("aut", "cre")),
-    person("Paul", "Egeler", email = "paulegeler@gmail.com", role = c("aut"), comment = c(ORCID = "0000-0001-6948-9498"))
+    person("Os", "Keyes", email = "ironholds@gmail.com", role = c("aut")),
+    person("Paul", "Egeler", email = "paulegeler@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-6948-9498"))
     )
 Description: Fast functions for dealing with prime numbers, such as testing
     whether a number is prime and generating a sequence prime numbers.

--- a/R/phi.R
+++ b/R/phi.R
@@ -34,7 +34,7 @@ phi_alt <- function(n) {
   # See Ironholds/primes#14 for details.
   vapply(
     prime_factors(n),
-    \(x) {
+    function(x) {
       runs <- rle(x)
       as.integer(prod(runs$values ** (runs$lengths - 1) * (runs$values - 1)))
       },

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Fast Functions for Prime Numbers in R
 [![Number of Downloads](https://cranlogs.r-pkg.org/badges/grand-total/primes)](https://cran.r-project.org/package=primes)
 
 **Authors**: Os Keyes and Paul Egeler  
-**License**: [MIT](https://opensource.org/license/mit/)  
+**License**: [MIT](https://opensource.org/license/mit)
 
 ## Description
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,12 @@
+## Version 1.6.1
+
+The failure observed in _tests/failures/testthat.Rout_ was inadvertently carried
+over from debugging version 1.5.1. The files have been purged and the path has
+been added to _.Rbuildignore_.
+
+We have also confirmed again that no undefined behavior is detected by running
+all tests using the `rocker/r-devel-ubsan-clang` on the latest build.
+
 ## Version 1.5.1
 
 ### Purpose


### PR DESCRIPTION
The previous build contained some debug files which caused some confusion. The debug files will now be excluded from the build.